### PR TITLE
Externalization of APIs 

### DIFF
--- a/capitains_nautilus/apis/base.py
+++ b/capitains_nautilus/apis/base.py
@@ -5,12 +5,17 @@ class AdditionalAPIPrototype:
     :ivar nautilus_extension: Nautilus extension
     :type nautilus_extension: capitains_nautilus.flask_ext.FlaskNautilus
     """
+    NAME = "Base"
     ROUTES = []
     Access_Control_Allow_Methods = {}
     CACHED = []
 
+    def __init__(self):
+        self.nautilus_extension = None
+
     def init_extension(self, nautilus_extension):
         self.nautilus_extension = nautilus_extension
+        nautilus_extension.register(self, self.NAME)
 
     @property
     def resolver(self):

--- a/capitains_nautilus/apis/base.py
+++ b/capitains_nautilus/apis/base.py
@@ -1,18 +1,15 @@
-from abc import abstractmethod
-from flask import current_app
-
-
 class AdditionalAPIPrototype:
     """ Additional APIs classes are used to connect new
     APIs to the Nautilus Flask Extensions
 
-    :param nautilus_extension: Nautilus extension
+    :ivar nautilus_extension: Nautilus extension
+    :type nautilus_extension: capitains_nautilus.flask_ext.FlaskNautilus
     """
     ROUTES = []
     Access_Control_Allow_Methods = {}
     CACHED = []
 
-    def __init__(self, nautilus_extension):
+    def init_extension(self, nautilus_extension):
         self.nautilus_extension = nautilus_extension
 
     @property

--- a/capitains_nautilus/apis/base.py
+++ b/capitains_nautilus/apis/base.py
@@ -1,0 +1,20 @@
+from abc import abstractmethod
+from flask import current_app
+
+
+class AdditionalAPIPrototype:
+    """ Additional APIs classes are used to connect new
+    APIs to the Nautilus Flask Extensions
+
+    :param nautilus_extension: Nautilus extension
+    """
+    ROUTES = []
+    Access_Control_Allow_Methods = {}
+    CACHED = []
+
+    def __init__(self, nautilus_extension):
+        self.nautilus_extension = nautilus_extension
+
+    @property
+    def resolver(self):
+        return self.nautilus_extension.resolver

--- a/capitains_nautilus/apis/cts.py
+++ b/capitains_nautilus/apis/cts.py
@@ -1,0 +1,239 @@
+from flask import render_template, Markup, request
+
+from MyCapytain.common.reference import URN
+from MyCapytain.common.constants import Mimetypes, RDF_NAMESPACES
+
+from capitains_nautilus.apis.base import AdditionalAPIPrototype
+from capitains_nautilus.errors import NautilusError, MissingParameter, InvalidURN
+
+
+class CTSApi(AdditionalAPIPrototype):
+    ROUTES = [
+        ('/cts', "r_cts", ["GET"])
+    ]
+    Access_Control_Allow_Methods = {
+        "r_cts": "OPTIONS, GET"
+    }
+    CACHED = [
+        #  CTS
+        "_get_capabilities", "_get_passage", "_get_passage_plus",
+        "_get_valid_reff", "_get_prev_next", "_get_first_urn", "_get_label",
+        "cts_error"
+    ]
+
+    def r_cts(self):
+        """ Actual main route of CTS APIs. Transfer typical requests through the ?request=REQUESTNAME route
+
+        :return: Response
+        """
+        _request = request.args.get("request", None)
+        if _request is not None:
+            try:
+                if _request.lower() == "getcapabilities":
+                    return self._get_capabilities(
+                        urn=request.args.get("urn", None)
+                    )
+                elif _request.lower() == "getpassage":
+                    return self._get_passage(
+                        urn=request.args.get("urn", None)
+                    )
+                elif _request.lower() == "getpassageplus":
+                    return self._get_passage_plus(
+                        urn=request.args.get("urn", None)
+                    )
+                elif _request.lower() == "getlabel":
+                    return self._get_label(
+                        urn=request.args.get("urn", None)
+                    )
+                elif _request.lower() == "getfirsturn":
+                    return self._get_first_urn(
+                        urn=request.args.get("urn", None)
+                    )
+                elif _request.lower() == "getprevnexturn":
+                    return self._get_prev_next(
+                        urn=request.args.get("urn", None)
+                    )
+                elif _request.lower() == "getvalidreff":
+                    return self._get_valid_reff(
+                        urn=request.args.get("urn", None),
+                        level=request.args.get("level", 1, type=int)
+                    )
+            except NautilusError as E:
+                return self.cts_error(error_name=E.__class__.__name__, message=E.__doc__)
+        return self.cts_error(MissingParameter.__name__, message=MissingParameter.__doc__)
+
+    def cts_error(self, error_name, message=None):
+        """ Create a CTS Error reply
+
+        :param error_name: Name of the error
+        :param message: Message of the Error
+        :return: CTS Error Response with information (XML)
+        """
+        self.nautilus_extension.logger.info(
+            "CTS error thrown {} for {} ({})".format(
+                error_name,
+                request.query_string.decode(),
+                message)
+        )
+        return render_template(
+            "cts/Error.xml",
+            errorType=error_name,
+            message=message
+        ), 404, {"content-type": "application/xml"}
+
+    def _get_capabilities(self, urn=None):
+        """ Provisional route for GetCapabilities request
+
+        :param urn: URN to filter the resource
+        :param inv: Inventory Identifier
+        :return: GetCapabilities response
+        """
+        r = self.resolver.getMetadata(objectId=urn)
+        if len(r.parents) > 0:
+            r = r.parents[-1]
+        r = render_template(
+            "cts/GetCapabilities.xml",
+            filters="urn={}".format(urn),
+            inventory=Markup(r.export(Mimetypes.XML.CTS))
+        )
+        return r, 200, {"content-type": "application/xml"}
+
+    def _get_passage(self, urn):
+        """ Provisional route for GetPassage request
+
+        :param urn: URN to filter the resource
+        :return: GetPassage response
+        """
+        urn = URN(urn)
+        subreference = None
+        if len(urn) < 4:
+            raise InvalidURN
+        if urn.reference is not None:
+            subreference = str(urn.reference)
+        node = self.resolver.getTextualNode(textId=urn.upTo(URN.NO_PASSAGE), subreference=subreference)
+
+        r = render_template(
+            "cts/GetPassage.xml",
+            filters="urn={}".format(urn),
+            request_urn=str(urn),
+            full_urn=node.urn,
+            passage=Markup(node.export(Mimetypes.XML.TEI))
+        )
+        return r, 200, {"content-type": "application/xml"}
+
+    def _get_passage_plus(self, urn):
+        """ Provisional route for GetPassagePlus request
+
+        :param urn: URN to filter the resource
+        :return: GetPassagePlus response
+        """
+        urn = URN(urn)
+        subreference = None
+        if len(urn) < 4:
+            raise InvalidURN
+        if urn.reference is not None:
+            subreference = str(urn.reference)
+        node = self.resolver.getTextualNode(textId=urn.upTo(URN.NO_PASSAGE), subreference=subreference)
+        r = render_template(
+            "cts/GetPassagePlus.xml",
+            filters="urn={}".format(urn),
+            request_urn=str(urn),
+            full_urn=node.urn,
+            prev_urn=node.prevId,
+            next_urn=node.nextId,
+            metadata={
+                "groupname": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.groupname)],
+                "title": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.title)],
+                "description": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.description)],
+                "label": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.label)]
+            },
+            citation=Markup(node.citation.export(Mimetypes.XML.CTS)),
+            passage=Markup(node.export(Mimetypes.XML.TEI))
+        )
+        return r, 200, {"content-type": "application/xml"}
+
+    def _get_valid_reff(self, urn, level):
+        """ Provisional route for GetValidReff request
+
+        :param urn: URN to filter the resource
+        :return: GetValidReff response
+        """
+        urn = URN(urn)
+        subreference = None
+        textId=urn.upTo(URN.NO_PASSAGE)
+        if urn.reference is not None:
+            subreference = str(urn.reference)
+        reffs = self.resolver.getReffs(textId=textId, subreference=subreference, level=level)
+        r = render_template(
+            "cts/GetValidReff.xml",
+            reffs=reffs,
+            urn=textId,
+            level=level,
+            request_urn=str(urn)
+        )
+        return r, 200, {"content-type": "application/xml"}
+
+    def _get_prev_next(self, urn):
+        """ Provisional route for GetPrevNext request
+
+        :param urn: URN to filter the resource
+        :param inv: Inventory Identifier
+        :return: GetPrevNext response
+        """
+        urn = URN(urn)
+        subreference = None
+        textId = urn.upTo(URN.NO_PASSAGE)
+        if urn.reference is not None:
+            subreference = str(urn.reference)
+        previous, nextious = self.resolver.getSiblings(textId=textId, subreference=subreference)
+        r = render_template(
+            "cts/GetPrevNext.xml",
+            prev_urn=previous,
+            next_urn=nextious,
+            urn=textId,
+            request_urn=str(urn)
+        )
+        return r, 200, {"content-type": "application/xml"}
+
+    def _get_first_urn(self, urn):
+        """ Provisional route for GetFirstUrn request
+
+        :param urn: URN to filter the resource
+        :param inv: Inventory Identifier
+        :return: GetFirstUrn response
+        """
+        urn = URN(urn)
+        subreference = None
+        textId = urn.upTo(URN.NO_PASSAGE)
+        if urn.reference is not None:
+            subreference = str(urn.reference)
+        firstId = self.resolver.getTextualNode(textId=textId, subreference=subreference).firstId
+        r = render_template(
+            "cts/GetFirstUrn.xml",
+            firstId=firstId,
+            full_urn=textId,
+            request_urn=str(urn)
+        )
+        return r, 200, {"content-type": "application/xml"}
+
+    def _get_label(self, urn):
+        """ Provisional route for GetLabel request
+
+        :param urn: URN to filter the resource
+        :param inv: Inventory Identifier
+        :return: GetLabel response
+        """
+        node = self.resolver.getTextualNode(textId=urn)
+        r = render_template(
+            "cts/GetLabel.xml",
+            request_urn=str(urn),
+            full_urn=node.urn,
+            metadata={
+                "groupname": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.groupname)],
+                "title": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.title)],
+                "description": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.description)],
+                "label": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.label)]
+            },
+            citation=Markup(node.citation.export(Mimetypes.XML.CTS))
+        )
+        return r, 200, {"content-type": "application/xml"}

--- a/capitains_nautilus/apis/cts.py
+++ b/capitains_nautilus/apis/cts.py
@@ -8,6 +8,7 @@ from capitains_nautilus.errors import NautilusError, MissingParameter, InvalidUR
 
 
 class CTSApi(AdditionalAPIPrototype):
+    NAME = "CTS"
     ROUTES = [
         ('/cts', "r_cts", ["GET"])
     ]

--- a/capitains_nautilus/apis/dts.py
+++ b/capitains_nautilus/apis/dts.py
@@ -1,0 +1,58 @@
+from flask import jsonify, request
+
+from MyCapytain.common.constants import Mimetypes
+
+from capitains_nautilus.apis.base import AdditionalAPIPrototype
+from capitains_nautilus.errors import NautilusError
+
+
+class DTSApi(AdditionalAPIPrototype):
+    ROUTES = [
+        ('/dts/collections', "r_dts_collection", ["GET", "OPTIONS"]),
+        ('/dts/collections/<objectId>', "r_dts_collections", ["GET", "OPTIONS"])
+    ]
+    Access_Control_Allow_Methods = {
+        "r_dts_collection": "OPTIONS, GET",
+        "r_dts_collections": "OPTIONS, GET"
+    }
+    CACHED = [
+        #  DTS
+        "r_dts_collections", "r_dts_collection", "dts_error"
+    ]
+
+    def dts_error(self, error_name, message=None):
+        """ Create a DTS Error reply
+
+        :param error_name: Name of the error
+        :param message: Message of the Error
+        :return: DTS Error Response with information (JSON)
+        """
+        self.logger.info("DTS error thrown {} for {} ({})".format(error_name, request.path, message))
+        j = jsonify({
+                "error": error_name,
+                "message": message
+            })
+        j.status_code = 404
+        return j
+
+    def r_dts_collection(self, objectId=None):
+        """ DTS Collection Metadata reply for given objectId
+
+        :param objectId: Collection Identifier
+        :return: JSON Format of DTS Collection
+        """
+        try:
+            j = self.resolver.getMetadata(objectId=objectId).export(Mimetypes.JSON.DTS.Std)
+            j = jsonify(j)
+            j.status_code = 200
+        except NautilusError as E:
+            return self.dts_error(error_name=E.__class__.__name__, message=E.__doc__)
+        return j
+
+    def r_dts_collections(self, objectId):
+        """ DTS Collection Metadata reply for given objectId
+
+        :param objectId: Collection Identifier
+        :return: JSON Format of DTS Collection
+        """
+        return self.r_dts_collection(objectId)

--- a/capitains_nautilus/apis/dts.py
+++ b/capitains_nautilus/apis/dts.py
@@ -7,6 +7,7 @@ from capitains_nautilus.errors import NautilusError
 
 
 class DTSApi(AdditionalAPIPrototype):
+    NAME = "DTS"
     ROUTES = [
         ('/dts/collections', "r_dts_collection", ["GET", "OPTIONS"]),
         ('/dts/collections/<objectId>', "r_dts_collections", ["GET", "OPTIONS"])
@@ -27,7 +28,9 @@ class DTSApi(AdditionalAPIPrototype):
         :param message: Message of the Error
         :return: DTS Error Response with information (JSON)
         """
-        self.logger.info("DTS error thrown {} for {} ({})".format(error_name, request.path, message))
+        self.nautilus_extension.logger.info("DTS error thrown {} for {} ({})".format(
+            error_name, request.path, message
+        ))
         j = jsonify({
                 "error": error_name,
                 "message": message

--- a/capitains_nautilus/flask_ext.py
+++ b/capitains_nautilus/flask_ext.py
@@ -76,10 +76,7 @@ class FlaskNautilus(object):
             }
         self.Access_Control_Allow_Origin = access_Control_Allow_Origin
         if not self.Access_Control_Allow_Origin:
-            self.Access_Control_Allow_Origin = {
-                k: v
-                for k, v in FlaskNautilus.Access_Control_Allow_Origin
-            }
+            self.Access_Control_Allow_Origin = FlaskNautilus.Access_Control_Allow_Origin
 
         for api in self.apis:
             api.init_extension(api)

--- a/capitains_nautilus/flask_ext.py
+++ b/capitains_nautilus/flask_ext.py
@@ -89,7 +89,7 @@ class FlaskNautilus(object):
         if self.name is None:
             self.name = __name__
 
-        if self.app:
+        if app:
             self.init_app(app=app)
 
     @property

--- a/capitains_nautilus/flask_ext.py
+++ b/capitains_nautilus/flask_ext.py
@@ -82,6 +82,7 @@ class FlaskNautilus(object):
             }
 
         for api in self.apis:
+            api.init_extension(api)
             self.ROUTES.extend(api.ROUTES)
             self.CACHED.extend(api.CACHED)
             self.Access_Control_Allow_Methods.update(api.Access_Control_Allow_Methods)

--- a/capitains_nautilus/flask_ext.py
+++ b/capitains_nautilus/flask_ext.py
@@ -66,7 +66,7 @@ class FlaskNautilus(object):
                 "The parameter apis will need to be set-up explicitely startin 2.0.0",
                 DeprecationWarning
             )
-            self.apis = {CTSApi(self), DTSApi(self)}
+            self.apis = {CTSApi(), DTSApi()}
 
         self.Access_Control_Allow_Methods = access_Control_Allow_Methods
         if not self.Access_Control_Allow_Methods:

--- a/capitains_nautilus/flask_ext.py
+++ b/capitains_nautilus/flask_ext.py
@@ -1,12 +1,11 @@
 from pkg_resources import resource_filename
 import logging
 
-from flask import Blueprint, request, render_template, Markup, jsonify, Response
+from flask import Blueprint, Response
 
-from MyCapytain.common.constants import Mimetypes, RDF_NAMESPACES
-from MyCapytain.common.reference import URN
 
-from capitains_nautilus.errors import NautilusError, MissingParameter, InvalidURN
+from capitains_nautilus.apis.cts import CTSApi
+from capitains_nautilus.apis.dts import DTSApi
 
 
 class FlaskNautilus(object):
@@ -23,6 +22,8 @@ class FlaskNautilus(object):
     :cvar access_Control_Allow_Origin: Dictionary with route name and allowed host over CORS or "*"
     :param logger: Logging handler.
     :type logger: logging
+    :param apis: Set of APIs to connect to Nautilus
+    :type apis: set of classes
 
     :cvar ROUTES: List of triple length tuples
     :cvar Access_Control_Allow_Methods: Dictionary with route name and allowed methods over CORS
@@ -33,34 +34,18 @@ class FlaskNautilus(object):
 
     :ivar resolver: CapiTainS resolver
     """
-    ROUTES = [
-        ('/cts', "r_cts", ["GET"]),
-        ('/dts/collections', "r_dts_collection", ["GET", "OPTIONS"]),
-        ('/dts/collections/<objectId>', "r_dts_collections", ["GET", "OPTIONS"])
-        #('/sparql', "r_sparql", ["GET"])
-    ]
-    Access_Control_Allow_Methods = {
-        "r_cts": "OPTIONS, GET",
-        "r_dts_collection": "OPTIONS, GET",
-        "r_dts_collections": "OPTIONS, GET"
-    }
+    ROUTES = []
+    CACHED = []
+    Access_Control_Allow_Methods = {}
     Access_Control_Allow_Origin = "*"
     LoggingHandler = logging.StreamHandler
-    CACHED = [
-        #  CTS
-        "_r_GetCapabilities", "_r_GetPassage", "_r_GetPassagePlus",
-        "_r_GetValidReff", "_r_GetPrevNext", "_r_GetFirstUrn", "_r_GetLabel",
-        "cts_error",
-        #  DTS
-        "r_dts_collections", "r_dts_collection", "dts_error"
-    ]
 
     def __init__(self, prefix="", app=None, name=None,
                  resolver=None,
                  flask_caching=None,
                  access_Control_Allow_Origin=None,
                  access_Control_Allow_Methods=None,
-                 logger=None
+                 logger=None, apis=None
         ):
         self.logger = None
         self.retriever = None
@@ -69,17 +54,37 @@ class FlaskNautilus(object):
 
         self.setLogger(logger)
 
-        self.app = app
         self.name = name
         self.prefix = prefix
         self.blueprint = None
 
+        self.routes = []
+
+        if apis is None:
+            from warnings import warn
+            warn(
+                "The parameter apis will need to be set-up explicitely startin 2.0.0",
+                DeprecationWarning
+            )
+            self.apis = {CTSApi(self), DTSApi(self)}
+
         self.Access_Control_Allow_Methods = access_Control_Allow_Methods
         if not self.Access_Control_Allow_Methods:
-            self.Access_Control_Allow_Methods = FlaskNautilus.Access_Control_Allow_Methods
+            self.Access_Control_Allow_Methods = {
+                k: v
+                for k, v in FlaskNautilus.Access_Control_Allow_Methods.items()
+            }
         self.Access_Control_Allow_Origin = access_Control_Allow_Origin
         if not self.Access_Control_Allow_Origin:
-            self.Access_Control_Allow_Origin = FlaskNautilus.Access_Control_Allow_Origin
+            self.Access_Control_Allow_Origin = {
+                k: v
+                for k, v in FlaskNautilus.Access_Control_Allow_Origin
+            }
+
+        for api in self.apis:
+            self.ROUTES.extend(api.ROUTES)
+            self.CACHED.extend(api.CACHED)
+            self.Access_Control_Allow_Methods.update(api.Access_Control_Allow_Methods)
 
         self.__flask_caching__ = flask_caching
 
@@ -121,9 +126,7 @@ class FlaskNautilus(object):
         :rtype: Blueprint
         """
 
-        self.app = app
-
-        self.init_blueprint()
+        self.init_blueprint(app)
 
         if self.flaskcache is not None:
             for func in self.CACHED:
@@ -131,7 +134,7 @@ class FlaskNautilus(object):
                 setattr(self, func.__name__, self.flaskcache.memoize()(func))
         return self.blueprint
 
-    def init_blueprint(self):
+    def init_blueprint(self, app):
         """ Properly generates the blueprint, registering routes and filters and connecting the app and the blueprint
 
         :return: Blueprint of the extension
@@ -145,7 +148,7 @@ class FlaskNautilus(object):
         )
 
         # Register routes
-        for url, name, methods in FlaskNautilus.ROUTES:
+        for url, name, methods in self.ROUTES:
             self.blueprint.add_url_rule(
                 url,
                 view_func=self.view(name),
@@ -153,7 +156,7 @@ class FlaskNautilus(object):
                 methods=methods
             )
 
-        self.app.register_blueprint(self.blueprint)
+        app.register_blueprint(self.blueprint)
         return self.blueprint
 
     def view(self, function_name):
@@ -183,255 +186,3 @@ class FlaskNautilus(object):
                 val[2].update(d)
                 return tuple(val)
         return r
-
-    def r_cts(self):
-        """ Actual main route of CTS APIs. Transfer typical requests through the ?request=REQUESTNAME route
-
-        :return: Response
-        """
-        _request = request.args.get("request", None)
-        if _request is not None:
-            try:
-                if _request.lower() == "getcapabilities":
-                    return self._r_GetCapabilities(
-                        urn=request.args.get("urn", None)
-                    )
-                elif _request.lower() == "getpassage":
-                    return self._r_GetPassage(
-                        urn=request.args.get("urn", None)
-                    )
-                elif _request.lower() == "getpassageplus":
-                    return self._r_GetPassagePlus(
-                        urn=request.args.get("urn", None)
-                    )
-                elif _request.lower() == "getlabel":
-                    return self._r_GetLabel(
-                        urn=request.args.get("urn", None)
-                    )
-                elif _request.lower() == "getfirsturn":
-                    return self._r_GetFirstUrn(
-                        urn=request.args.get("urn", None)
-                    )
-                elif _request.lower() == "getprevnexturn":
-                    return self._r_GetPrevNext(
-                        urn=request.args.get("urn", None)
-                    )
-                elif _request.lower() == "getvalidreff":
-                    return self._r_GetValidReff(
-                        urn=request.args.get("urn", None),
-                        level=request.args.get("level", 1, type=int)
-                    )
-            except NautilusError as E:
-                return self.cts_error(error_name=E.__class__.__name__, message=E.__doc__)
-        return self.cts_error(MissingParameter.__name__, message=MissingParameter.__doc__)
-
-    def cts_error(self, error_name, message=None):
-        """ Create a CTS Error reply
-
-        :param error_name: Name of the error
-        :param message: Message of the Error
-        :return: CTS Error Response with information (XML)
-        """
-        self.logger.info("CTS error thrown {} for {} ({})".format(error_name, request.query_string.decode(), message))
-        return render_template(
-            "cts/Error.xml",
-            errorType=error_name,
-            message=message
-        ), 404, {"content-type": "application/xml"}
-
-    def dts_error(self, error_name, message=None):
-        """ Create a DTS Error reply
-
-        :param error_name: Name of the error
-        :param message: Message of the Error
-        :return: DTS Error Response with information (JSON)
-        """
-        self.logger.info("DTS error thrown {} for {} ({})".format(error_name, request.path, message))
-        j = jsonify({
-                "error": error_name,
-                "message": message
-            })
-        j.status_code = 404
-        return j
-
-    def r_dts_collection(self, objectId=None):
-        """ DTS Collection Metadata reply for given objectId
-
-        :param objectId: Collection Identifier
-        :return: JSON Format of DTS Collection
-        """
-        try:
-            j = self.resolver.getMetadata(objectId=objectId).export(Mimetypes.JSON.DTS.Std)
-            j = jsonify(j)
-            j.status_code = 200
-        except NautilusError as E:
-            return self.dts_error(error_name=E.__class__.__name__, message=E.__doc__)
-        return j
-
-    def r_dts_collections(self, objectId):
-        """ DTS Collection Metadata reply for given objectId
-
-        :param objectId: Collection Identifier
-        :return: JSON Format of DTS Collection
-        """
-        return self.r_dts_collection(objectId)
-
-    def _r_GetCapabilities(self, urn=None):
-        """ Provisional route for GetCapabilities request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetCapabilities response
-        """
-        r = self.resolver.getMetadata(objectId=urn)
-        if len(r.parents) > 0:
-            r = r.parents[-1]
-        r = render_template(
-            "cts/GetCapabilities.xml",
-            filters="urn={}".format(urn),
-            inventory=Markup(r.export(Mimetypes.XML.CTS))
-        )
-        return r, 200, {"content-type": "application/xml"}
-
-    def _r_GetPassage(self, urn):
-        """ Provisional route for GetPassage request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetPassage response
-        """
-        urn = URN(urn)
-        subreference = None
-        if len(urn) < 4:
-            raise InvalidURN
-        if urn.reference is not None:
-            subreference = str(urn.reference)
-        node = self.resolver.getTextualNode(textId=urn.upTo(URN.NO_PASSAGE), subreference=subreference)
-
-        r = render_template(
-            "cts/GetPassage.xml",
-            filters="urn={}".format(urn),
-            request_urn=str(urn),
-            full_urn=node.urn,
-            passage=Markup(node.export(Mimetypes.XML.TEI))
-        )
-        return r, 200, {"content-type": "application/xml"}
-
-    def _r_GetPassagePlus(self, urn):
-        """ Provisional route for GetPassagePlus request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetPassagePlus response
-        """
-        urn = URN(urn)
-        subreference = None
-        if len(urn) < 4:
-            raise InvalidURN
-        if urn.reference is not None:
-            subreference = str(urn.reference)
-        node = self.resolver.getTextualNode(textId=urn.upTo(URN.NO_PASSAGE), subreference=subreference)
-        r = render_template(
-            "cts/GetPassagePlus.xml",
-            filters="urn={}".format(urn),
-            request_urn=str(urn),
-            full_urn=node.urn,
-            prev_urn=node.prevId,
-            next_urn=node.nextId,
-            metadata={
-                "groupname": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.groupname)],
-                "title": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.title)],
-                "description": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.description)],
-                "label": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.label)]
-            },
-            citation=Markup(node.citation.export(Mimetypes.XML.CTS)),
-            passage=Markup(node.export(Mimetypes.XML.TEI))
-        )
-        return r, 200, {"content-type": "application/xml"}
-
-    def _r_GetValidReff(self, urn, level):
-        """ Provisional route for GetValidReff request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetValidReff response
-        """
-        urn = URN(urn)
-        subreference = None
-        textId=urn.upTo(URN.NO_PASSAGE)
-        if urn.reference is not None:
-            subreference = str(urn.reference)
-        reffs = self.resolver.getReffs(textId=textId, subreference=subreference, level=level)
-        r = render_template(
-            "cts/GetValidReff.xml",
-            reffs=reffs,
-            urn=textId,
-            level=level,
-            request_urn=str(urn)
-        )
-        return r, 200, {"content-type": "application/xml"}
-
-    def _r_GetPrevNext(self, urn):
-        """ Provisional route for GetPrevNext request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetPrevNext response
-        """
-        urn = URN(urn)
-        subreference = None
-        textId = urn.upTo(URN.NO_PASSAGE)
-        if urn.reference is not None:
-            subreference = str(urn.reference)
-        previous, nextious = self.resolver.getSiblings(textId=textId, subreference=subreference)
-        r = render_template(
-            "cts/GetPrevNext.xml",
-            prev_urn=previous,
-            next_urn=nextious,
-            urn=textId,
-            request_urn=str(urn)
-        )
-        return r, 200, {"content-type": "application/xml"}
-
-    def _r_GetFirstUrn(self, urn):
-        """ Provisional route for GetFirstUrn request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetFirstUrn response
-        """
-        urn = URN(urn)
-        subreference = None
-        textId = urn.upTo(URN.NO_PASSAGE)
-        if urn.reference is not None:
-            subreference = str(urn.reference)
-        firstId = self.resolver.getTextualNode(textId=textId, subreference=subreference).firstId
-        r = render_template(
-            "cts/GetFirstUrn.xml",
-            firstId=firstId,
-            full_urn=textId,
-            request_urn=str(urn)
-        )
-        return r, 200, {"content-type": "application/xml"}
-
-    def _r_GetLabel(self, urn):
-        """ Provisional route for GetLabel request
-
-        :param urn: URN to filter the resource
-        :param inv: Inventory Identifier
-        :return: GetLabel response
-        """
-        node = self.resolver.getTextualNode(textId=urn)
-        r = render_template(
-            "cts/GetLabel.xml",
-            request_urn=str(urn),
-            full_urn=node.urn,
-            metadata={
-                "groupname": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.groupname)],
-                "title": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.title)],
-                "description": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.description)],
-                "label": [(literal.language, str(literal)) for literal in node.metadata.get(RDF_NAMESPACES.CTS.label)]
-            },
-            citation=Markup(node.citation.export(Mimetypes.XML.CTS))
-        )
-        return r, 200, {"content-type": "application/xml"}

--- a/tests/test_flask_ext/test_classiccapitainsctsresolver.py
+++ b/tests/test_flask_ext/test_classiccapitainsctsresolver.py
@@ -50,17 +50,17 @@ class TestClassicCTSResolverRestAPICache(CTSModule, DTSModule, TestCase, Nautilu
     ATTRIB_RESOLVER = False
 
     def setUp(self):
-        app = Flask("Nautilus")
+        self._app = Flask("Nautilus")
         self.cache = Cache(config={'CACHE_TYPE': 'simple'})
         self.nautilus = FlaskNautilus(
-            app=app,
+            app=self._app,
             resolver=NautilusCTSResolver(["./tests/test_data/latinLit"]),
             flask_caching=self.cache,
             logger=logger
         )
-        app.debug = True
-        self.cache.init_app(app)
-        self.app = app.test_client()
+        self._app.debug = True
+        self.cache.init_app(self._app)
+        self.app = self._app.test_client()
         self.parent = HttpCtsRetriever("/cts")
         self.resolver = HttpCtsResolver(endpoint=self.parent)
         logassert.setup(self, self.nautilus.logger.name)
@@ -90,6 +90,10 @@ class TestClassicCTSResolverRestAPICache(CTSModule, DTSModule, TestCase, Nautilu
         self.parent.called = []
         self.parent.call = lambda x: call(self.parent, x)
 
+    def tearDown(self):
+        del self._app
+        del self.app
+        del self.nautilus
 
 class TestClassicCTSResolverRestAPILogging(NautilusCTSResolverGenerator, LoggingModule, SetupModule, TestCase):
     """ Test the rest API logging system with the legacy resolver that uses full file """


### PR DESCRIPTION
I externalized the APIs responsability so that:
- Nautilus keeps it easy to maintain and add new web interfaces
- Nautilus keeps it easy to move from CTS content to non-CTS content (which will be the focus of Capitains forward)
- Nautilus has ability to subclass APIs