### PR TITLE
Replace Werkzeug.contrib.cache with cachelib

### DIFF
--- a/capitains_nautilus/cmd.py
+++ b/capitains_nautilus/cmd.py
@@ -2,7 +2,7 @@
 
 from capitains_nautilus.flask_ext import FlaskNautilus
 from capitains_nautilus.cts.resolver.base import NautilusCtsResolver
-from werkzeug.contrib.cache import FileSystemCache, RedisCache, NullCache
+from cachelib import FileSystemCache, RedisCache, NullCache
 from flask import Flask
 import argparse
 import logging

--- a/capitains_nautilus/cts/resolver/base.py
+++ b/capitains_nautilus/cts/resolver/base.py
@@ -7,7 +7,7 @@ from MyCapytain.common.constants import set_graph, get_graph
 from MyCapytain.common.reference import URN, CtsReference
 from MyCapytain.resolvers.cts.local import CtsCapitainsLocalResolver
 from MyCapytain.resources.texts.local.capitains.cts import CapitainsCtsText as Text
-from werkzeug.contrib.cache import NullCache
+from cachelib import NullCache
 
 from capitains_nautilus import _cache_key
 from capitains_nautilus.collections.sparql import clear_graph

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ mock==2.0.0
 rdflib-sqlalchemy>=0.3.8
 bsddb3==6.2.6
 typing
-urltools==0.3.2
+urltools>=0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.12
-Werkzeug>=0.11.3,<1.0.0
+cachelib>=0.1.0
 redis>=2.10.5
 Flask-Caching>=1.4.0,<2.0.0
 MyCapytain>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.12
-Werkzeug>=0.11.3
+Werkzeug>=0.11.3,<1.0.0
 redis>=2.10.5
 Flask-Caching>=1.4.0,<2.0.0
 MyCapytain>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     "mock",
     "nose",
     "typing",
-    "urltools==0.3.2"
+    "urltools>=0.3.2"
   ],
   extras_require={
     "Berkeley": ["bsddb3==6.2.6"],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
   install_requires=[
     "MyCapytain>=2.0.0",
     "Flask>=0.12",
-    "Werkzeug>=0.11.3,<1.0.0",
+    "cachelib>=0.1.0",
     "Flask-Caching>=1.4.0,<2.0.0"
     "typing",
   ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
   install_requires=[
     "MyCapytain>=2.0.0",
     "Flask>=0.12",
-    "Werkzeug>=0.11.3",
+    "Werkzeug>=0.11.3,<1.0.0",
     "Flask-Caching>=1.4.0,<2.0.0"
     "typing",
   ],

--- a/tests/cts/scripts/run_cache.py
+++ b/tests/cts/scripts/run_cache.py
@@ -6,7 +6,7 @@ sys.path.append(
 )
 
 from capitains_nautilus.cts.resolver import NautilusCtsResolver
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from tests.cts.config import subprocess_repository, subprocess_cache_dir
 
 cache = FileSystemCache(subprocess_cache_dir)

--- a/tests/cts/scripts/run_cache_sparql.py
+++ b/tests/cts/scripts/run_cache_sparql.py
@@ -6,7 +6,7 @@ sys.path.append(
 )
 
 from capitains_nautilus.cts.resolver import SparqlAlchemyNautilusCtsResolver
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from tests.cts.config import subprocess_repository, subprocess_cache_dir, sqlite_address
 
 cache = FileSystemCache(subprocess_cache_dir)

--- a/tests/cts/scripts/run_cache_sparql_sleepy_cat.py
+++ b/tests/cts/scripts/run_cache_sparql_sleepy_cat.py
@@ -6,7 +6,7 @@ sys.path.append(
 )
 
 from capitains_nautilus.cts.resolver import SleepyCatCtsResolver
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from tests.cts.config import subprocess_repository, subprocess_cache_dir, sleepy_cat_address
 
 cache = FileSystemCache(subprocess_cache_dir)

--- a/tests/cts/test_resolver_cache.py
+++ b/tests/cts/test_resolver_cache.py
@@ -7,7 +7,7 @@ from capitains_nautilus.cts.resolver import \
     SparqlAlchemyNautilusCtsResolver,\
     NautilusCtsResolver
 from capitains_nautilus.collections.sparql import clear_graph
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from MyCapytain.common.constants import Mimetypes
 from tests.cts.config import subprocess_cache_dir, subprocess_repository, sqlite_address, \
     sleepy_cat_address

--- a/tests/test_cli/app.py
+++ b/tests/test_cli/app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from flask import Flask
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from flask_caching import Cache
 from tests.test_cli.config import subprocess_repository, subprocess_cache_dir, http_cache_dir
 

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -11,7 +11,7 @@ from tests.test_cli.config import subprocess_cache_dir, http_cache_dir, subproce
 from tests.test_cli.app import resolver, nautilus_cache, make_dispatcher, app, nautilus
 from flask import Flask
 from flask_caching import Cache
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from capitains_nautilus.cts.resolver import NautilusCtsResolver
 from capitains_nautilus.flask_ext import FlaskNautilus
 
@@ -27,7 +27,7 @@ python = executable
 class TestManager(TestCase):
     """ Test the manager ability to preprocess and cache some resources
 
-    .. note:: Werkzeug File System Cache leaves a cache file to indicate the number of other cache files . More in
+    .. note:: FileSystemCache leaves a cache file to indicate the number of other cache files . More in
     https://github.com/Capitains/Nautilus/issues/62 and https://github.com/pallets/werkzeug/blob/8393ee88aaacf7bcd3a0b1d604511f70c222df25/werkzeug/contrib/cache.py#L773-L781
     """
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from flask import Flask
 from flask_caching import Cache
 from click.testing import CliRunner
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 from MyCapytain.resources.prototypes.cts.inventory import CtsTextInventoryCollection as TextInventoryCollection
 
 from capitains_nautilus.flask_ext import FlaskNautilus


### PR DESCRIPTION
Attempt to bump some dependencies to un-bitrot this.
- `urltools` 0.3.2 went away
- `werkzeug.contrib.cache` is now `cachelib`

NB I haven't gotten the tests to run, so please take that into account when reviewing!