### PR TITLE
fix errors preventing Nautilus to start

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ resolver.parse()
 
 app = Flask("Nautilus")
 nautilus = FlaskNautilus(
+    name="nautilus",
     app=app,
     resolver=resolver
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     "MyCapytain>=2.0.0",
     "Flask>=0.12",
     "cachelib>=0.1.0",
-    "Flask-Caching>=1.4.0,<2.0.0"
+    "Flask-Caching>=1.4.0,<2.0.0",
     "typing",
   ],
   tests_require=[


### PR DESCRIPTION
There was a missing comma, so `python setup.py develop` didn't work.
We also need to pass in a `name` to `FlaskNautilus` in `app.py`, otherwise it chooses the default name `capitains_nautilus.flask_ext`, producing the error `ValueError: 'name' may not contain a dot '.' character.`

This PR fixes both problems. Closes #94.