### PR TITLE
Correct @id return value from r_navigation

### DIFF
--- a/capitains_nautilus/apis/dts.py
+++ b/capitains_nautilus/apis/dts.py
@@ -469,7 +469,8 @@ class DTSApi(AdditionalAPIPrototype):
             },
             "level": references.level,
             "passage": url_for(".dts_document", id=objectId, _external=self._external)+"{&ref}{&start}{&end}",
-            "@id": url_for(".dts_navigation", **params),
+            "@id": objectId,
+            "dts:references": url_for(".dts_navigation", **params),
             "hydra:member": [_ref_to_dict(ref) for ref in references]
         }
         if references.citation:


### PR DESCRIPTION
The `@id` key in the response from r_navigation is actually the url path to the current navigation request. Here I have changed the return for `@id` to the objectId and moved the url path that was in `@id` to a new `dts:references` key. This seems to make more sense to me but perhaps it doesn't conform to the standard.